### PR TITLE
Autosave after dragging, except when viewing old revisions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ chardet==3.0.4
 defusedxml==0.5.0
 Django==2.0.2
 django-allauth==0.35.0
+django-anymail==3.0
 django-appconf==1.0.2
 django-avatar==4.1.0
 django-bower==5.2.0

--- a/static/js/seating.js
+++ b/static/js/seating.js
@@ -5,6 +5,7 @@
 
     let seatingRevisions = [];
     let unassignedUsers;
+    let revisionNumber = null;
 
     let currentSeatHasUser;
     let dragging = false;
@@ -100,6 +101,8 @@
             giveSeatToUser(seat, draggingUser.user_id);
 
         dragStop(event);
+        if(revisionNumber === null)
+            commitRevision();
     }
 
     function dragStopOnUnassigned(event) {
@@ -109,6 +112,8 @@
         giveUnassignedToUser(draggingUser.user_id);
 
         dragStop(event);
+        if(revisionNumber === null)
+            commitRevision();
     }
 
     function handleTouchEnd(event) {
@@ -265,8 +270,10 @@
             }
             else {
                 finishSave('Saved');
-                if(response.length && isExec)
+                if(response.length && isExec) {
                     addRevision(JSON.parse(response).revision);
+                    revisionNumber = null;
+                }
             }
         });
     }
@@ -365,8 +372,10 @@
                 refreshUnassigned();
                 refreshSeats();
 
-                if(revision !== null)
+                if(revision !== null) {
+                    revisionNumber = revision;
                     enableSave();
+                }
             }
         });
     }
@@ -424,6 +433,12 @@
 
         updateToRevision(null);
         updateRevisionList();
+        setInterval(() => {
+            if(!dragging && revisionNumber === null)
+                updateToRevision(null);
+
+            updateRevisionList();
+        }, 5000);
     });
 
 })();


### PR DESCRIPTION
When viewing old revisions (exec only) you must press save manually to return to live mode (to prevent massively accidental changes).
For most users the layout is autosaved upon dropping.  The layout is loaded every 5s unless you're currently dragging someone.