### PR TITLE
Removed old signup prompt for tournaments

### DIFF
--- a/events/templates/tournaments/tournament_home.html
+++ b/events/templates/tournaments/tournament_home.html
@@ -224,10 +224,6 @@
           <li><strong>Signups open:</strong> {{ tournament.signup_start|date:'P l jS F Y' }}</li>
           <li><strong>Signups close:</strong> {{ tournament.signup_end|date:'P l jS F Y' }}</li>
         </ul>
-        {% if tournament.signups_open and not user_signup %}
-          <p>Signups are open! The sign up form is available here: <a
-              href="{{ tournament.signup_form }}">{{ tournament.signup_form }}</a></p>
-        {% endif %}
       </div>
       {% if request.user.is_authenticated %}
         <div class="signup-tile">


### PR DESCRIPTION
The new signup system removes signup forms - there is still some reference to them in the template which I don't believe (correct me if I'm wrong) can be used.

This renders as:
https://i.gyazo.com/932fca5d6c24dc7f14398eccef79a2e2.png